### PR TITLE
Korrektur, Presseberichte

### DIFF
--- a/content/events.md
+++ b/content/events.md
@@ -7,7 +7,7 @@ description: "Events um den  Flugplatz und  Aeroclub"
 ---
 Hier gibt es Informationen zu vergangenen und bevorstehenden Veranstaltungen rund um den Flugplatz und den Aero-Club. 
  
-* <a href = "/flugplatzfest">09.07.2017, Sonntag, Tag der offenen Tür , Sonderflugplatz Baden-Oos</a>
+* <a href = "/flugplatzfest">09.07.2017, Sonntag, Tag der offenen Tür, Sonderlandeplatz Baden-Oos</a>
 * <a href = "/riesenwiesenfest">16.07.2017, Sonntag, Riesenwiesenfest mit Astir-Präsentation, Lichtentaler Allee, Baden-Baden</a>
 * <a href = "/marktplatzfest"> 21.07 bis 23.7.2017, Vereinsstand mit Flammkuchen beim Marktplatzfest Baden-Baden, Altstadt</a>
 * <a href = "">28. August bis 8. September 2017,  Schulungs- und Fluglager, Sonderlandeplatz Baden-Oos</a>

--- a/content/presseberichte/adler_2016_12.md
+++ b/content/presseberichte/adler_2016_12.md
@@ -5,7 +5,7 @@ title: "Erfolgreicher Flugtag für behinderte und chronisch kranke Kinder"
 slug: "adler1216"
 author: "Axel Schulze"
 HeaderImgUrl: "/img/header/header_fschlepp4.jpg"
-press: "Adler 12/2016"
+press: "der adler 12/2016"
 pressfile: "http://www.bwlv.de/de/inhalt/verband/geschaeftsstelle/redaktion-der-adler/magazin-online-lesen/downloads/kategorie/1.html"
 pressimage: "/img/pressreports/adler1216_22-23.jpg"
 ---

--- a/content/presseberichte/adler_2017_08.md
+++ b/content/presseberichte/adler_2017_08.md
@@ -5,7 +5,7 @@ title: "Team Baden-Württemberg erfolgreich beim Deutschlandflug"
 slug: "adler0817"
 author: "Sergius Miller"
 HeaderImgUrl: "/img/header/header_fschlepp4.jpg"
-press: "Adler 08/2018"
+press: "der adler 08/2017"
 pressfile: "http://www.bwlv.de/de/inhalt/verband/geschaeftsstelle/redaktion-der-adler/magazin-online-lesen/downloads/kategorie/0.html"			   
 pressimage: "/img/pressreports/adler2017_8_de_flug.jpg"
 ---

--- a/content/presseberichte/bnn_2017_07_13.md
+++ b/content/presseberichte/bnn_2017_07_13.md
@@ -2,7 +2,7 @@
 date: "2017-07-13T14:11:29+02:00"
 draft: false
 title: "Abheben und über allem schweben"
-slug: "bnn_artikel"
+slug: "bnn_artikel_13_07_2017"
 author: "Sergej Miller"
 HeaderImgUrl: "/img/header/header_fschlepp4.jpg"
 press: "Badische Neueste Nachrichten"

--- a/layouts/presseberichte/single.html
+++ b/layouts/presseberichte/single.html
@@ -9,7 +9,7 @@
         <img src="{{ .Params.pressimage }}"alt="{{ .Title }}"/>
       </a>
       <div class="caption">{{ .Title }}</div>
-      <div class="attribution">Artikel von {{ .Params.press }}</div>
+      <div class="attribution">Quelle '{{ .Params.press }}'</div>
     </figure>
   </main>
 </div>


### PR DESCRIPTION
1. Fehlerkorrektur
2. Presseberichte : 'Quelle' anstatt von 'Artikel von'